### PR TITLE
Docker prune cli

### DIFF
--- a/cmd/base.go
+++ b/cmd/base.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os/exec"
 
 	"github.com/urfave/cli"
 )
@@ -13,6 +14,22 @@ func SetupBase(c []cli.Command) []cli.Command {
 		Usage:   "Show a hello world command line",
 		Action: func(c *cli.Context) {
 			fmt.Println("Hello World")
+		},
+	})
+
+	c = append(c, cli.Command{
+		Name:     "docker-clean",
+		Category: "Docker",
+		Usage:    "Cleans docker enviroment",
+		Action: func(c *cli.Context) {
+			command := exec.Command("docker", "stop $(docker ps -aq) && docker rm $(docker ps -qa) && docker network prune -f")
+			output, erro := command.CombinedOutput()
+			if erro != nil {
+				fmt.Println(fmt.Sprint(erro) + ": " + string(output))
+				return
+			}
+			fmt.Println("Docker is now clean")
+
 		},
 	})
 

--- a/cmd/base.go
+++ b/cmd/base.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/urfave/cli"
 )
@@ -31,13 +32,19 @@ func SetupBase(c []cli.Command) []cli.Command {
 				fmt.Println("No docker images found")
 				return
 			}
-			commandStop := exec.Command("docker", "stop")
-			commandStop.Run()
-			commandRmv := exec.Command("docker", "rm", out.String())
-			outputRmv, erroRmv := commandRmv.CombinedOutput()
-			if erroRmv != nil {
-				fmt.Println(fmt.Sprint(erroRmv) + ": " + string(outputRmv))
-				return
+			containers := strings.Split(out.String(), "\n")
+			for cont := range containers {
+				if len(containers[cont]) == 0 {
+					continue
+				}
+				commandStop := exec.Command("docker", "stop", containers[cont])
+				commandStop.Run()
+				commandRmv := exec.Command("docker", "rm", containers[cont])
+				outputRmv, erroRmv := commandRmv.CombinedOutput()
+				if erroRmv != nil {
+					fmt.Println(fmt.Sprint(erroRmv) + ": " + string(outputRmv))
+					return
+				}
 			}
 			commandPrune := exec.Command("docker", "network", "prune")
 			outputPrune, erroPrune := commandPrune.CombinedOutput()
@@ -46,7 +53,6 @@ func SetupBase(c []cli.Command) []cli.Command {
 				return
 			}
 			fmt.Println("Docker is now clean")
-
 		},
 	})
 


### PR DESCRIPTION
Agora o `main docker-clean` pode substituir um longo comando: 
`docker stop $(docker ps -aq) && docker rm $(docker ps -qa) && docker network prune -f`
